### PR TITLE
Cleaning dataset

### DIFF
--- a/cleaning_location_group.sql
+++ b/cleaning_location_group.sql
@@ -1,0 +1,64 @@
+---original parking_transactions_cleaning view modified by adding CASE WHEN for location_group 
+
+SELECT 
+   parking_tr.ID AS id
+   , parking_tr.Source AS `source`
+   , DurationinMinutes AS duration_minute
+   , FORMAT_TIMESTAMP('%F %T', StartTime) AS start_time
+   , FORMAT_TIMESTAMP('%F %T', EndTime) AS end_time
+   , Amount AS amount
+   , KioskID AS kiosk_id
+   , AppZoneID AS app_zone_id
+   , AppZoneGroup AS app_zone_group
+   , PaymentMethod AS payment_method
+   , CASE
+       ---null values replaced with 'Unknown location' 
+       WHEN AppZoneID = 101.0 THEN 'Unknown Location'
+       ---'Unknown location' replaced with 'South Congress', 'Woods of Westlake', "Dawson's Lot" depending on the AppZoneGroup
+       WHEN AppZoneGroup = 'SoCo PTMD'  THEN 'South Congress'
+       WHEN AppZoneGroup = 'Woods of Westlake'  THEN 'Woods of Westlake'
+       WHEN AppZoneGroup = 'PARD (Parking Lots)' THEN "Dawson's Lot"
+       ELSE LocationGroup
+     END AS location_group
+   , FORMAT_TIMESTAMP('%F %T', LastUpdated) AS last_updated
+FROM `parking-transactions.main.parking_transactions` as parking_tr
+
+
+---Running queries on the updated parking_transactions_cleaning view to double check the results
+
+---Now we have unknown location only if the payment has been done through parking meters source or if the payment was done via app but there is No Zone Group
+SELECT DISTINCT `source`, app_zone_group, payment_method, location_group
+FROM `parking-transactions.main.parking_transactions_cleaned` 
+WHERE location_group = 'Unknown Location'
+ORDER BY `source`, app_zone_group, payment_method, location_group;
+
+---No null location_group anymore
+SELECT DISTINCT `source`, app_zone_group, payment_method, location_group
+FROM `parking-transactions.main.parking_transactions_cleaned` 
+WHERE location_group IS NULL
+ORDER BY `source`, app_zone_group, payment_method, location_group
+
+--- 110923 passport-web, 6693137 passport-app, 8240734 parking meters
+SELECT 
+  `source`
+  ,COUNT(*) as nb
+FROM `parking-transactions.main.parking_transactions_cleaned` 
+GROUP BY `source`
+
+---kiosk_id is null when the payment has been done through the app or the web --> 6693137 null values for passport-app and 110923 null values for passport-web
+SELECT 
+  `source`
+  ,COUNT(*) as nb_kiosk_id_null
+FROM `parking-transactions.main.parking_transactions_cleaned` 
+WHERE kiosk_id IS NULL
+GROUP BY `source`
+
+---on the contrary app_zone_id is null when source is parking meters --> 8240734 null values
+SELECT 
+  `source`
+  ,COUNT(*) as nb_appzoneid_null
+FROM `parking-transactions.main.parking_transactions_cleaned` 
+WHERE app_zone_id IS NULL
+GROUP BY `source`
+
+

--- a/cleaning_negatives_and_outliers.sql
+++ b/cleaning_negatives_and_outliers.sql
@@ -1,0 +1,47 @@
+-- The first CTE is to swap the start_time and end_time when the duration is negative
+
+WITH transfo AS (
+  SELECT  
+    ID AS id,  
+    Source AS source, 
+    DurationinMinutes,
+    -- Casting the start and end time to Date time for Date_diff later
+    CAST(
+      CASE 
+        WHEN StartTime > EndTime THEN EndTime
+        ELSE StartTime
+      END AS DATETIME) AS start_time, 
+    CAST(
+        CASE
+          WHEN StartTime > EndTime THEN StartTime
+          ELSE EndTime
+        END AS DATETIME 
+    ) AS end_time,
+    Amount AS amount
+   , KioskID AS kiosk_id
+   , AppZoneID AS app_zone_id
+   , AppZoneGroup AS app_zone_group
+   , PaymentMethod AS payment_method
+   , LocationGroup AS location_group
+   , FORMAT_TIMESTAMP('%F %T', LastUpdated) AS last_updated
+  FROM `parking-transactions.main.parking_transactions`
+)
+SELECT
+  id,
+  source,
+  -- Date_diff to only have positive values
+  DATE_DIFF(end_time, start_time, MINUTE) AS duration_minutes,
+  -- formatting the date_time to remove the T in the original values
+  FORMAT_DATETIME('%F %T',DATETIME(start_time)) AS start_time,
+  FORMAT_DATETIME('%F %T',DATETIME(end_time)) AS end_time,
+  amount,
+  kiosk_id, 
+  app_zone_group, 
+  app_zone_id, 
+  payment_method, 
+  location_group, 
+  last_updated
+FROM transfo
+-- Filtering for values under 600 minutes. There is a difference of + 759 entries compared to expected outcome, not sure where it's coming from
+WHERE DATE_DIFF(end_time, start_time, MINUTE) <= 600
+ORDER BY transfo.id

--- a/count_uniques.sql
+++ b/count_uniques.sql
@@ -1,0 +1,81 @@
+# How many different payment methods we have: 10 different ones. Need to capitalize them.
+
+SELECT 
+  DISTINCT(PaymentMethod),
+  COUNT(*) AS nb
+FROM `parking-transactions.main.parking_transactions`
+GROUP BY PaymentMethod
+ORDER BY PaymentMethod;
+
+# How many different sources we have: 3, Parking Meters, App and Web
+SELECT 
+  DISTINCT(Source),
+  COUNT(*) AS nb
+FROM `parking-transactions.main.parking_transactions`
+GROUP BY Source
+ORDER BY Source;
+
+# What is the max, min amount of money spend: 147 dollars and 0 dollars.
+SELECT 
+  MAX(Amount) AS max_amount,
+  MIN(Amount) AS min_amount
+FROM `parking-transactions.main.parking_transactions`;
+
+# What is the max and min time spend: 7201106.5 (would mean around 13 years) and -861.1, probably outliers.
+SELECT 
+  MAX(DurationinMinutes) AS max_duration,
+  MIN(DurationinMinutes) AS min_duration
+FROM `parking-transactions.main.parking_transactions`;
+
+# Checking how many lines are negatives in DurationInMinutes: 31, need to investigate
+SELECT
+  ID,
+  StartTime,
+  EndTime,
+  DurationinMinutes
+FROM `parking-transactions.main.parking_transactions`
+WHERE DurationinMinutes <0;
+
+/* After further investigation, the problem was coming from end date and start date being inverted. It needs to be cleaned.*/
+
+-- Parking in Texas is not allowed to be higher than 10 hours per session, or 600 minutes. How many are above than that ? 
+
+SELECT 
+  duration_minute,
+  start_time,
+  end_time,
+  amount
+FROM `parking-transactions.main.parking_transactions_cleaned`
+WHERE duration_minute > 600; -- 150446, less than 1% of the dataset has duration longer than 10 hours.
+
+-- There are some big outliers, probably caused because the end time was set to 2034. 
+SELECT
+  kiosk_id,
+  duration_minute, 
+  start_time,
+  end_time,
+  amount,
+  app_zone_group,
+  source
+FROM `parking-transactions.main.parking_transactions_cleaned`
+WHERE end_time > '2034-01-01'
+ORDER BY end_time, kiosk_id DESC;
+
+/* After further investigation, it seems impossible to book or stay longer than 10 hours or 600 minutes parked in Austin. The amount are not matching this wide amount of time, so to be sure I would remove them.
+There are 150446 entries above 600 minutes, and 1 negative that is above 600 minutes. The final table should have 14 894 347 rows */ 
+
+# How many different KioskID we have: 930.
+SELECT 
+  DISTINCT(KioskID),
+  COUNT(*) AS nb
+FROM `parking-transactions.main.parking_transactions`
+GROUP BY KioskID
+ORDER BY KioskID;
+
+# How many different Location Group we have: 27, including the nulls
+SELECT 
+  DISTINCT(LocationGroup),
+  COUNT(*) AS nb
+FROM `parking-transactions.main.parking_transactions`
+GROUP BY LocationGroup
+ORDER BY LocationGroup;

--- a/rename_columns_BQ.sql
+++ b/rename_columns_BQ.sql
@@ -1,0 +1,14 @@
+SELECT 
+   parking_tr.ID AS id
+   , parking_tr.Source AS `source`
+   , DurationinMinutes AS duration_minute
+   , FORMAT_TIMESTAMP('%F %T', StartTime) AS start_time
+   , FORMAT_TIMESTAMP('%F %T', EndTime) AS end_time
+   , Amount AS amount
+   , KioskID AS kiosk_id
+   , AppZoneID AS app_zone_id
+   , AppZoneGroup AS app_zone_group
+   , PaymentMethod AS payment_method
+   , LocationGroup AS location_group
+   , FORMAT_TIMESTAMP('%F %T', LastUpdated) AS last_updated
+FROM `parking-transactions.main.parking_transactions` as parking_tr


### PR DESCRIPTION
Main cleaning steps:

- Renaming the columns
- Casting the start_time and end_time to DATETIME
- Removing duration_in_minutes above 600 minutes, and the negatives
- Cleaning the 'nulls' and 'Unknown Location' in location_group when possible