### PR TITLE
cleaning_final_outliers

### DIFF
--- a/cleaning_negatives_and_outliers.sql
+++ b/cleaning_negatives_and_outliers.sql
@@ -49,6 +49,6 @@ SELECT
   location_group, 
   last_updated
 FROM transformation
--- Filtering out the values above 600 minutes
-WHERE DATE_DIFF(end_time, start_time, MINUTE) <= 600
+-- Filtering out the values above 4315 minutes. Parking for 3 days is a possibility we should include. Outliers (more than 3 days) are excluded. 
+WHERE DATE_DIFF(end_time, start_time, MINUTE) <= 4315
 ORDER BY transfo.id


### PR DESCRIPTION
Including the duration_in_minutes that are in the 3 days parking window, as we couldn't rule out it was outliers. Parking for more than 3 days is an outlier